### PR TITLE
Explicit login instructions and two minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ cfa753dfea5e: Image successfully pushed
 latest: digest: sha256:15eda5ab78f31658ab922650eebe9da9ccc6c16462d5ef0bfd6d9f29b8800569 size: 2743
 ```
 
-If you are not automatically prompted to log in, you can explicitly log in before pushing, with ``docker login 0.0.0.0:5000``.
+If you are not automatically prompted to log in, you can explicitly log in before pushing, with `docker login 0.0.0.0:5000`.
 
 ## Test that LDAP auth is working
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ cfa753dfea5e: Image successfully pushed
 latest: digest: sha256:15eda5ab78f31658ab922650eebe9da9ccc6c16462d5ef0bfd6d9f29b8800569 size: 2743
 ```
 
+If you are not automatically prompted to log in, you can explicitly log in before pushing, with ``docker login 0.0.0.0:5000``.
+
 ## Test that LDAP auth is working
 
 This will connect to the LDAP and query all information below the base (`-b`).

--- a/auth/config/auth_config.yml
+++ b/auth/config/auth_config.yml
@@ -26,7 +26,7 @@ ldap_auth:
   # specify them here. Plain text password is read from the file.
   bind_dn: "uid=serviceaccount,ou=it,dc=example,dc=com"
   # Make sure you remove newlines and carriage returns from the password file.
-  bind_password_file: /tmp/ldap_password.txt.clean
+  bind_password_file: /config/ldap_password.txt
   # User query settings. ${account} is expanded from auth request 
   base: "ou=musicians,dc=example,dc=com"
   filter: "(&(uid=${account})(objectClass=organizationalPerson))"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ registry:
 
 auth:
   image: cesanta/docker_auth
-  entrypoint: /start.sh
   ports:
     - "5001:5001"
   links:


### PR DESCRIPTION
When I tried running this, it threw back this error:
docker push localhost:5000/mozart/busybox

```
The push refers to a repository [localhost:5000/mozart/busybox]
5f70bf18a086: Image push failed
16a7ebd37800: Preparing
Get http://localhost:5000/v2/: malformed HTTP response "\x15\x03\x01\x00\x02\x02"
```

The solution was to explicitly log in first with `docker login localhost:5000`.
