### PR TITLE
Update README and startscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ to authenticate against LDAP (eg. `mozart` and `password`). You should get an
 correctly.
 
 ```
-curl -H "Authorization: Basic $(echo "USERNAME:PASSWORD" | base64)" -vk "https://127.0.0.1:5001/auth?service=Docker%20registry&scope=registry:catalog:*"
+curl -H "Authorization: Basic $(echo -n "USERNAME:PASSWORD" | base64)" -vk "https://127.0.0.1:5001/auth?service=Docker%20registry&scope=registry:catalog:*"
 ```
 
 # Manual token-based workflow to list repositories

--- a/auth/start.sh
+++ b/auth/start.sh
@@ -14,4 +14,4 @@ if [ -f $CONF_PATH.custom ]; then
 fi
 
 # Start the auth server
-/auth_server -v=5 -alsologtostderr=true -log_dir=/logs $CONF_PATH
+/docker_auth/auth_server -v=5 -alsologtostderr=true -log_dir=/logs $CONF_PATH


### PR DESCRIPTION
This fixes a minor documentation bug in README.md (the test command won't work)

Additionally the start.sh script is updated to the current image version (fixes #8)